### PR TITLE
Remove sync button

### DIFF
--- a/Phoenix/Controllers/DashboardController.cs
+++ b/Phoenix/Controllers/DashboardController.cs
@@ -105,7 +105,7 @@ namespace Phoenix.Controllers
 
             var temp = (JArray)TempData["kingdom"];
             List<string> kingdom = temp.ToObject<List<string>>();
-
+            dashboardService.SyncRoomRcisFor(kingdom);
             var buildingRCIs = dashboardService.GetRcisForBuilding(kingdom);
 
             return View(buildingRCIs);
@@ -136,7 +136,7 @@ namespace Phoenix.Controllers
             // RD is not in RoomAssign, so there will be nothing under currentRoomNumber and currentBuilding.
             var temp = (JArray)TempData["kingdom"];
             List<string> kingdom = temp.ToObject<List<string>>();
-
+            dashboardService.SyncRoomRcisFor(kingdom);
             var buildingRcis = dashboardService.GetRcisForBuilding(kingdom);
             
             return View(buildingRcis);
@@ -152,16 +152,7 @@ namespace Phoenix.Controllers
             return routeToTake[state][role];
                 
         }
-        [HttpGet]
-        public ActionResult SyncRcis()
-        {
-            var temp = (JArray)TempData["kingdom"];
-            List<string> kingdom = temp.ToObject<List<string>>();
-
-            dashboardService.SyncRoomRcisFor(kingdom);
-            dashboardService.SyncCommonAreaRcisFor(kingdom);
-            return RedirectToAction("Index");
-        }
+        
         // Potentially later: admin option that can view all RCI's for all buildings
 
         // Maybe use an authorization filter here to only allow an RD to access this method?

--- a/Phoenix/Views/Shared/_Layout.cshtml
+++ b/Phoenix/Views/Shared/_Layout.cshtml
@@ -37,10 +37,6 @@
                     <i class="material-icons hamburger">menu</i>    
                 </button>
                 <ul class="dropdown-menu">
-                    @if (ViewBag.Role == "RD" || ViewBag.Role == "RA")
-                    {
-                        <li class="dropdown-menu-item"><a href="@Url.Action(actionName: "SyncRcis", controllerName: "Dashboard")"><i class="material-icons">sync</i>Sync Rcis</a></li>
-                    }
                     @if (ViewBag.Role == "RD")
                     {
                         <li class="dropdown-menu-item"><a href="@Url.Action(actionName: "SignAllRD", controllerName: "RciInput")">Batch Sign RCI Checkins</a></li>


### PR DESCRIPTION
- Another short one.
- Remove the sync button. Syncing happens automatically on login now.
- No need to sync common areas on login. The sync functionality was created so that the RA can access rooms with freshmen before they move in. Apartments have upperclasspeeps, so they will generate the common area rci when they log in.