### PR TITLE
Forgot to include which RciID to redirect to.

### DIFF
--- a/Phoenix/Controllers/RciCheckoutController.cs
+++ b/Phoenix/Controllers/RciCheckoutController.cs
@@ -49,7 +49,7 @@ namespace Phoenix.Controllers
                 ViewBag.CostDictionary = componentService.GetCostDictionary("common", rci.BuildingCode);
                 if (rci.CheckoutSigRD != null)
                 {
-                    return RedirectToAction("RciReview");
+                    return RedirectToAction("RciReview", new { id = id } );
                 }
                 return View("CommonArea", rci);
             }
@@ -59,7 +59,7 @@ namespace Phoenix.Controllers
                 ViewBag.CostDictionary = componentService.GetCostDictionary("individual", rci.BuildingCode);
                 if (rci.CheckoutSigRD != null)
                 {
-                    return RedirectToAction("RciReview");
+                    return RedirectToAction("RciReview", new { id = id });
                 }
                 return View("IndividualRoom", rci);
             }

--- a/Phoenix/Controllers/RciInputController.cs
+++ b/Phoenix/Controllers/RciInputController.cs
@@ -49,7 +49,7 @@ namespace Phoenix.Controllers
             //  Redirect to the review page if this is already signed by the RD
             if(rci.CheckinSigRD != null)
             {
-                return RedirectToAction("RciReview");
+                return RedirectToAction("RciReview", new { id = id });
             }
 
             // This is how we access items set in the filter.


### PR DESCRIPTION
I got an error when I tried to manually navigate (by editing the url) to the RciInput/RciCheckout index page of a completed RCI i.e signed by the RD. Normally, it should have just redirected me to the RciReview page.

The problem was that I was not passing the RciID to the redirect method.