### PR TITLE
Avoid returning nulls inside services

### DIFF
--- a/Phoenix/Controllers/LoginController.cs
+++ b/Phoenix/Controllers/LoginController.cs
@@ -4,7 +4,7 @@ using System.Web.Mvc;
 using System.DirectoryServices.AccountManagement;
 using Phoenix.Models.ViewModels;
 using Phoenix.Services;
-
+using Phoenix.Exceptions;
 
 namespace Phoenix.Controllers
 {
@@ -40,67 +40,63 @@ namespace Phoenix.Controllers
             // Get the username and password from the view model
             string username = loginViewModel.Username;
             string password = loginViewModel.Password;
-            if (password == null)
+
+            try
             {
-                // if user did not enter a password, set it to empty string, since this value must be non-null
-                password = "";
+                _ADContext = loginService.ConnectToADServer();
+            }
+            catch (Exception e)
+            {
+                loginViewModel.ErrorMessage = "There was a problem connection to the server. We are sorry. Please try again later or contact the project maintainer.";
+                return View("Index", loginViewModel);
+            }
+      
+            UserPrincipal userEntry;
+            try
+            {
+                userEntry = loginService.FindUser(username, _ADContext);
+            }
+            catch(UserNotFoundException ex)
+            {
+                _ADContext.Dispose();
+                loginViewModel.ErrorMessage = "Oh dear, it seems that username or password is invalid.";
+                return View("Index", loginViewModel);
+            }
+            catch(ArgumentNullException ex)
+            {
+                _ADContext.Dispose();
+                loginViewModel.ErrorMessage = "Please make sure you enter in values for the username.";
+                return View("Index", loginViewModel);
             }
 
-            if (!ModelState.IsValid)
+            if (loginService.IsValidUser(username, password, _ADContext))
             {
-                loginViewModel.ErrorMessage = "Invalid model state.";
-                return View("Index", loginViewModel);
+                // Generate token and attach to header
+                string jwtToken;
+                try
+                {
+                    jwtToken = loginService.GenerateToken(username, userEntry.EmployeeId);
+                }
+                catch(InvalidUserException ex)
+                {
+                    // e.g. user is a staff member.
+                    _ADContext.Dispose();
+                    loginViewModel.ErrorMessage = "Sorry, you are not a student or a member of the Residence Life Staff, so you do not have access to this system.";
+                    return View("Index", loginViewModel);
+                } 
+
+                HttpCookie tokenCookie = new HttpCookie("Authentication");
+                tokenCookie.Value = jwtToken;
+                tokenCookie.Expires = DateTime.Now.AddHours(2.0);
+                Response.Cookies.Add(tokenCookie);
+
+                _ADContext.Dispose();
+                return RedirectToAction("Index", "Dashboard");
             }
             else
             {
-                try
-                {
-                    _ADContext = loginService.ConnectToADServer();
-                }
-                catch (Exception e)
-                {
-                    loginViewModel.ErrorMessage = "There was a problem connection to the server. We are sorry. Please try again later or contact a system administrator.";
-                    return View("Index", loginViewModel);
-                }
-                if (_ADContext != null)
-                {
-                    var userEntry = loginService.FindUser(username, _ADContext);
-                    if (userEntry == null)
-                    {
-                        _ADContext.Dispose();
-                        loginViewModel.ErrorMessage = "Oh dear, it seems that username or password is invalid.";
-                        return View("Index", loginViewModel);
-                    }
-                    // If user does exist in Active Directory, try to validate him or her
-                    else
-                    {
-                        if (loginService.IsValidUser(username, password, _ADContext))
-                        {
-
-                            // I think we could add code here for authorization of admin, etc.
-
-                            // Generate token and attach to header
-                            var jwtToken = loginService.GenerateToken(username, userEntry.EmployeeId);
-                            HttpCookie tokenCookie = new HttpCookie("Authentication");
-                            tokenCookie.Value = jwtToken;
-                            tokenCookie.Expires = DateTime.Now.AddHours(2.0);
-                            Response.Cookies.Add(tokenCookie);
-
-                            _ADContext.Dispose();
-                            return RedirectToAction("Index", "Dashboard");
-                        }
-                        else
-                        {
-                            loginViewModel.ErrorMessage = "Oh dear, it seems that username or password is invalid.";
-                            return View("Index", loginViewModel);
-                        }
-                    }
-                }
-                else
-                {
-                    loginViewModel.ErrorMessage = "Oh dear, it seems that username or password is invalid.";
-                    return View("Index", loginViewModel);
-                }
+                loginViewModel.ErrorMessage = "Oh dear, it seems that username or password is invalid.";
+                return View("Index", loginViewModel);
             }
         }
     }

--- a/Phoenix/Exceptions/DatabaseEntryNotFound.cs
+++ b/Phoenix/Exceptions/DatabaseEntryNotFound.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Phoenix.Exceptions
+{
+    /// <summary>
+    /// Exception thrown by services when we expect to find a record in the database, but don't find it. 
+    /// </summary>
+    public class DatabaseEntryNotFound : Exception
+    {
+        public DatabaseEntryNotFound()
+            : base()
+        { }
+
+        public DatabaseEntryNotFound(string message)
+            : base(message)
+        { }
+
+        public DatabaseEntryNotFound(string message, Exception innerException)
+            :base(message, innerException)
+        { }
+    }
+}

--- a/Phoenix/Exceptions/InvalidUserException.cs
+++ b/Phoenix/Exceptions/InvalidUserException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Phoenix.Exceptions
+{
+    /// <summary>
+    /// Exception gets thrown when a user that is not authorized to use the system tries to login. e.g Faculty or non-Admin/non-RD staff
+    /// </summary>
+    public class InvalidUserException : Exception
+    {
+        public InvalidUserException()
+            : base()
+        { }
+
+        public InvalidUserException(string message)
+            : base(message)
+        { }
+
+        public InvalidUserException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+    }
+}

--- a/Phoenix/Exceptions/UserNotFoundException.cs
+++ b/Phoenix/Exceptions/UserNotFoundException.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Phoenix.Exceptions
+{
+    /// <summary>
+    /// Exception to be thrown by services when a user we expect to find is not found.
+    /// </summary>
+    public class UserNotFoundException : Exception
+    {
+        private string user = "";
+
+        public UserNotFoundException(string usr)
+            :base(string.Format("The user {0} was not found.", usr))
+        {
+            user = usr;
+        }
+
+        public UserNotFoundException(string usr, Exception innerException)
+            : base(string.Format("The user {0} was not found.", usr), innerException)
+        {
+            user = usr;
+        }
+
+        public string NotFoundUser()
+        {
+            return user;
+        }
+    }
+}

--- a/Phoenix/Filters/ExceptionLogAttribute.cs
+++ b/Phoenix/Filters/ExceptionLogAttribute.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+using System.Web.Hosting;
+using System.Web.Mvc;
+
+namespace Phoenix.Filters
+{
+    public class ExceptionLogAttribute : FilterAttribute, IExceptionFilter
+    {
+        public void OnException(ExceptionContext filterContext)
+        {
+            string today = DateTime.Today.ToShortDateString().Replace("/", "_");
+
+            // Msdn doesn't have enough documentation on DateTime, so I used:
+            // http://www.c-sharpcorner.com/uploadfile/mahesh/working-with-datetime-using-C-Sharp/
+            // to figure out the type of timestamp format I wanted
+            string timestamp = DateTime.Today.ToString("G");
+
+            string folderPath = "\\Logs\\";
+            Directory.CreateDirectory(HostingEnvironment.MapPath(folderPath));
+
+            var stream = File.AppendText(HostingEnvironment.MapPath(folderPath + today + ".log"));
+
+            stream.Write(timestamp);
+            stream.Write(" --- ");
+            stream.Write("[ERROR]");
+            stream.Write(" ");
+            // Unsolicited information: The user agent string is a mess.
+            // Here is an article to get you up to date:
+            // http://webaim.org/blog/user-agent-string-history/
+            // FUN
+            stream.WriteLine(filterContext.HttpContext.Request.UserAgent);
+            stream.Write(filterContext.HttpContext.Request.UserHostAddress);
+            stream.Write(" ");
+            stream.Write(filterContext.HttpContext.Request.HttpMethod.ToString());
+            stream.Write(" ");
+            stream.WriteLine(filterContext.HttpContext.Request.Url.ToString());
+
+            stream.WriteLine("Exception: " + filterContext.Exception.Message);
+
+            stream.WriteLine("Inner Exception: "  + filterContext.Exception.InnerException);
+
+            stream.WriteLine();
+            stream.WriteLine();
+           
+
+            stream.Dispose();
+        }
+    }
+}

--- a/Phoenix/Global.asax.cs
+++ b/Phoenix/Global.asax.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Phoenix.Filters;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
@@ -12,6 +13,9 @@ namespace Phoenix
     {
         protected void Application_Start()
         {
+            // Register global filter
+            GlobalFilters.Filters.Add(new ExceptionLogAttribute());
+
             AreaRegistration.RegisterAllAreas();
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);

--- a/Phoenix/Phoenix.csproj
+++ b/Phoenix/Phoenix.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Exceptions\UserNotFoundException.cs" />
     <Compile Include="Filters\CustomAuthenticationAttribute.cs" />
     <Compile Include="Filters\AdminAttribute.cs" />
+    <Compile Include="Filters\ExceptionLogAttribute.cs" />
     <Compile Include="Filters\RDAttribute.cs" />
     <Compile Include="Filters\ResLifeStaffAttribute.cs" />
     <Compile Include="Global.asax.cs">

--- a/Phoenix/Phoenix.csproj
+++ b/Phoenix/Phoenix.csproj
@@ -154,6 +154,9 @@
     <Compile Include="Controllers\RciCheckoutController.cs" />
     <Compile Include="Controllers\RciComponentReassignController.cs" />
     <Compile Include="Controllers\RciInputController.cs" />
+    <Compile Include="Exceptions\DatabaseEntryNotFound.cs" />
+    <Compile Include="Exceptions\InvalidUserException.cs" />
+    <Compile Include="Exceptions\UserNotFoundException.cs" />
     <Compile Include="Filters\CustomAuthenticationAttribute.cs" />
     <Compile Include="Filters\AdminAttribute.cs" />
     <Compile Include="Filters\RDAttribute.cs" />

--- a/Phoenix/Services/AdminDashboardService.cs
+++ b/Phoenix/Services/AdminDashboardService.cs
@@ -91,43 +91,8 @@ namespace Phoenix.Services
 
             foreach (var e in rciTypes)
             {
-                //var buildingCode = e.Attributes().Select(x => x.Name).Where(x => (x != "roomType" && x != "id"));
-
                 var buildingCode = e.Attribute("buildingCode").Value;
                 string dormStyle;
-
-                // If there are multiple buildings accounted for by a certain element <rciType>, we have to give it some overarching label
-                // e.g. HUD
-                //if (buildings.Count()  > 1 )
-                //{
-                //    // Check if HUD - originally I was not going to check all options, because if the rciType has one HUD, it has them all
-                //    // But I thought that might be risky in case one HUD gets removed. (BECAUSE LEWIS... you're days are numbered >.<)
-                //    if (buildings.Contains("WIL") || buildings.Contains("LEW") || buildings.Contains("EVA")) {
-                //        result.Add("HUD");
-                //    }
-                //    // Check if Road halls
-                //    else if (buildings.Contains("DEX") || buildings.Contains("GED") || buildings.Contains("GRA") || buildings.Contains("CON")
-                //        || buildings.Contains("HIL") || buildings.Contains("MCI") || buildings.Contains("RID"))
-                //    {
-                //        result.Add("Road Halls");
-                //    }
-                //    // Check for Ferrin/Drew
-                //    else if (buildings.Contains("FER") || buildings.Contains("DRE"))
-                //    {
-                //        result.Add("Ferrin/Drew");
-                //    }
-                //    else if (buildings.Contains("CHA") || buildings.Contains("FUL"))
-                //    {
-                //        result.Add("Chase/Fulton");
-                //    }
-                //}
-
-                // Needs thought: all those hard-coded checks above ^^ seem like they will make the system very brittle
-                // In order to change which buildings are associated, it will require a source code change. And it will not
-                // be possible for a new rci type to be added for multiple buildings in the future.
-                // What I am thinking: Maybe we should make it a one-for-one relationship between buildings and RCI types
-                // Yes, it will be some duplication, but it allows the user more power/customization when we are gone.
-                // #maintainability
                 
                 if (e.Attribute("roomType").Value.Equals("common"))
                 {

--- a/Phoenix/Services/DashboardService.cs
+++ b/Phoenix/Services/DashboardService.cs
@@ -23,15 +23,14 @@ namespace Phoenix.Services
             document = XDocument.Load(HttpContext.Current.Server.MapPath("~/App_Data/RoomComponents.xml"));
         }
 
-        /*
-         * Get a set of RCI's, depending on certain parameters, such as building, year, etc.
-         * This method is used in admin Find RCIs tool
-         * If no params are specified, returns all
-         * 
-         * @params: building - a building specified to get rci's for
-         *          year - a session specificed to get rci's for
-         * @returns: A collection of RCI View Models
-         */
+        /// <summary>
+        /// Get a set of RCI's, depending on certain parameters, such as building, year, etc.
+        /// This method is used in admin Find RCIs tool
+        /// If no params are specified, returns all
+        /// </summary>
+        /// <param name="building">a building specified to get rci's for</param>
+        /// <param name="year"> a session specificed to get rci's for</param>
+        /// <returns>A collection of RCI View Models</returns>
         public IEnumerable<HomeRciViewModel> GetRcis(string building = null, string year = null)
         {
             if (building != null)
@@ -62,11 +61,11 @@ namespace Phoenix.Services
             }
         }
 
-        /*
-         * Get the RCI for an individual resident
-         * @params: id - resident's Gordon id
-         * @return: A collection of RCI View Models (which should contain only 1)
-         */ 
+        ///<summary>
+        /// Get the RCI for an individual resident
+        ///</summary>
+        ///<param  name="id">resident's Gordon id </params> 
+        ///<returns>A collection of RCI View Models (which should contain only 1)</returns>
         public IEnumerable<HomeRciViewModel> GetRcisForResident(string id)
         {
             if(id == null)
@@ -95,13 +94,12 @@ namespace Phoenix.Services
             return RCIs;
         }
 
-        /*
-         * Display all RCI's for the corresponding building 
-         * @params: buildingCode - code(s) for the building(s) of the RA or RD's sphere of authority
-         */
+        ///<summary>
+        /// Display all RCI's for the corresponding building 
+        ///</summary>
+        ///<param name="buildingCode">code(s) for the building(s) of the RA or RD's sphere of authority</param>
         public IEnumerable<HomeRciViewModel> GetRcisForBuilding(List<string> buildingCode)
         {
-            // Not sure if this will end up with duplicates for the RA's own RCI
             var buildingRCIs =
                 from personalRCI in db.Rci
                 join account in db.Account on personalRCI.GordonID equals account.ID_NUM into rci
@@ -126,11 +124,13 @@ namespace Phoenix.Services
         }
 
 
-        /*
-         * Create RCI Components that are associated with a single RCI, according to room type
-         * @params: rciId - the id of the RCI to associate with 
-         *          roomType - string to indicate type of room, either "common area" or "dorm room" currently
-         */ 
+        ///<summary>
+        /// Create RCI Components that are associated with a single RCI, according to room type
+        ///</summary>
+        ///<param name="document">Xml document containing room components</param>
+        ///<param name="rciId">the id of the RCI to associate with </param>
+        ///<param name="roomType">string to indicate type of room, either "common area" or "dorm room" currently</param>
+        ///<param name="buildingCode">building code for the rci we are about to create</param>
         public List<RciComponent> CreateRciComponents(XDocument document, int rciId, string roomType, string buildingCode)
         {
             List<RciComponent> created = new List<RciComponent>();
@@ -165,12 +165,12 @@ namespace Phoenix.Services
         }
 
 
-        /*
-         * Get the current common area RCIs for an apartment
-         * @params: apartmentNumber - the apartment's number
-         *          building - the building where the apartment is located
-         * @return: the common area, if any, that was found in the db
-         */ 
+        ///<summary>
+        /// Get the current common area RCIs for an apartment
+        ///</summary>
+        ///<param name="apartmentNumber">the apartment's number</param>
+        ///<param name="building">the building where the apartment is located</param>
+        ///<returns>the common area, if any, that was found in the db</returns>
         public IEnumerable<HomeRciViewModel> GetCommonAreaRci(string currentRoom, string building)
         {
             var apartmentNumber = currentRoom.TrimEnd(new char[] { 'A', 'B', 'C', 'D' });
@@ -198,27 +198,23 @@ namespace Phoenix.Services
 
         }
 
-        /*
-         * Generate a csv file of fines for rci's from current, according to buildings of RD
-         * Right now this is just generating for all buildings. We could add specificity so that RD can choose 
-         * which building to pull from.
-         * CSV format: RoomNumber, BuildingCode, Name, id, DetailedReason, FineAmount 
-         * 
-         */
-         public string GenerateFinesSpreadsheet(List<string> buildingCodes)
+         /// <summary>
+         /// Generate a csv file of fines for rci's from current, according to buildings of RD
+         /// </summary>
+         /// <param name="buildingCodes">The building for which to generate a fines spreadsheet</param>
+        public string GenerateFinesSpreadsheet(List<string> buildingCodes)
         {
             var currentSession = GetCurrentSession();
             var csvString = "Room Number,Building Code,Name,ID,Detailed Reason,Charge Amount,Behavioral Fine\n";
 
-            // ***** This does not handle common areas! *****
-            // We should talk to MC about how he wants common area fine assignment to be handled in the system
             var fineQueries =
                 from rci in db.Rci
                 join component in db.RciComponent on rci.RciID equals component.RciID
                 join fine in db.Fine on component.RciComponentID equals fine.RciComponentID
                 join account in db.Account on fine.GordonID equals account.ID_NUM
                 where buildingCodes.Contains(rci.BuildingCode) && rci.IsCurrent.Value == true
-                && fine.FineAmount > 0 // Don't include $0 fines in the query. These will be present when an RD wants to work request something, but not
+                && fine.FineAmount > 0 
+                // Don't include $0 fines in the query. These will be present when an RD wants to work request something, but not
                 // charge the resident for it e.g. Window blinds need to be replaced.
                 select new
                 {
@@ -247,10 +243,10 @@ namespace Phoenix.Services
             return csvString;
         } 
 
-        /*
-         * Query the db for the current session, which will be the session with the most recent SESS_BEGN_DTE
-         * @return: string that contains the code for the current session
-         */
+        ///<summary>
+        /// Query the db for the current session, which will be the session with the most recent SESS_BEGN_DTE
+        ///</summary>
+        ///<returns>string that contains the code for the current session</returns>
          public string GetCurrentSession()
         {
             var today = DateTime.Now;
@@ -535,7 +531,7 @@ namespace Phoenix.Services
         }
 
         /// <summary>
-        /// Create a route dictionary that will tell us where to go, given the rci state and the role of the user.
+        /// Create a route dictionary that will tell us where to go given the rci state and the role of the user.
         /// </summary>
         public Dictionary<string, Dictionary<string, ActionResult>> GetRciRouteDictionary(int rciID)
         {

--- a/Phoenix/Services/RciComponentReassignService.cs
+++ b/Phoenix/Services/RciComponentReassignService.cs
@@ -2,6 +2,9 @@
 using Phoenix.Models.ViewModels;
 using System.Linq;
 
+/// <summary>
+/// ~ Currently not being used ~
+/// </summary>
 namespace Phoenix.Services
 {
     public class RciComponentReassignService

--- a/Phoenix/Services/RciInputService.cs
+++ b/Phoenix/Services/RciInputService.cs
@@ -43,29 +43,6 @@ namespace Phoenix.Services
             return buildingRCIs.OrderBy(m => m.RoomNumber);
         }
 
-        /*public IEnumerable<SignAllRDViewModel> GetCheckedRcis(string gordonID)
-        {
-            var rcis =
-                from r in db.Rci
-                where r.CheckinSigRDGordonID == gordonID
-                where r.CheckinSigRD == null
-                join a in db.Account on r.GordonID equals a.ID_NUM into account
-                from temp in account.DefaultIfEmpty()
-                select new SignAllRDViewModel()
-                {
-                    RciID = r.RciID,
-                    GordonID = r.GordonID,
-                    FirstName = temp.firstname ?? "Common Area",
-                    LastName = temp.lastname ?? "Rci",
-                    BuildingCode = r.BuildingCode,
-                    RoomNumber = r.RoomNumber
-                };
-                
-            return rcis;
-        }*/
-
-       
-
         /// <summary>
         /// Get the rci for a common area by id
         /// </summary>
@@ -352,7 +329,6 @@ namespace Phoenix.Services
             // Now that we have the image rotated correctly, remove the exif information so that
             // other programs don't try to adjust the image again based on the exif data.
             image.RemovePropertyItem(274);
-
         } 
 
         public IEnumerable<string> GetCommonRooms(int id)


### PR DESCRIPTION
This pull request is mainly for @superpowers11 but @fallcat, you can review it too if you would like 👍 

#154 

🎉 One more month before this gets fully used 🎉 

_As usual please don't be intimidated by the GitHub-produced diffs. They exaggerate the amount of changes I made._

This pull request focuses on removing the `return null` expressions from the LoginService. I replace them with throwing Exceptions.  
I think this is a good idea because:
- This explicitly lets faculty/non-reslife staff know upfront that they can't access the system instead of showing them an ugly error page :/
- Throwing an exception with a message tells the developer exactly what failed, where and why. This is in contrast to returning null which will eventually throw an unhelpful `ArgumentNullException` down the line if something went wrong.
- Flattens logic i.e. No more nested if/else in the `LoginController`

Testing:
- Currently writing UI tests for this. I will be testing login attempts with valid, invalid, missing and staff credentials (e.g. 360.facultytest; lol I forgot this existed 🐐 )
- I have manually tested this by:
    - Successfully login in as myself.
    - Getting an error message when I try to log in with no credentials
    - Getting an error message when I try to log in with incorrect credentials.
    - Getting an error message when I try to log in as 360.facultytest