### PR TITLE
Exception logging

### DIFF
--- a/Phoenix/Filters/ExceptionLogAttribute.cs
+++ b/Phoenix/Filters/ExceptionLogAttribute.cs
@@ -1,50 +1,37 @@
-﻿using System;
+﻿using Phoenix.Services;
+using System;
 using System.IO;
+using System.Text;
 using System.Web.Hosting;
 using System.Web.Mvc;
 
 namespace Phoenix.Filters
 {
+    /// <summary>
+    /// Log any uncaught exceptions in controller classes.
+    /// </summary>
     public class ExceptionLogAttribute : FilterAttribute, IExceptionFilter
     {
         public void OnException(ExceptionContext filterContext)
         {
-            string today = DateTime.Today.ToShortDateString().Replace("/", "_");
+            LoggerService log = new LoggerService();
+            StringBuilder message  = new StringBuilder();
 
-            // Msdn doesn't have enough documentation on DateTime, so I used:
-            // http://www.c-sharpcorner.com/uploadfile/mahesh/working-with-datetime-using-C-Sharp/
-            // to figure out the type of timestamp format I wanted
-            string timestamp = DateTime.Today.ToString("G");
-
-            string folderPath = "\\Logs\\";
-            Directory.CreateDirectory(HostingEnvironment.MapPath(folderPath));
-
-            var stream = File.AppendText(HostingEnvironment.MapPath(folderPath + today + ".log"));
-
-            stream.Write(timestamp);
-            stream.Write(" --- ");
-            stream.Write("[ERROR]");
-            stream.Write(" ");
             // Unsolicited information: The user agent string is a mess.
             // Here is an article to get you up to date:
             // http://webaim.org/blog/user-agent-string-history/
             // FUN
-            stream.WriteLine(filterContext.HttpContext.Request.UserAgent);
-            stream.Write(filterContext.HttpContext.Request.UserHostAddress);
-            stream.Write(" ");
-            stream.Write(filterContext.HttpContext.Request.HttpMethod.ToString());
-            stream.Write(" ");
-            stream.WriteLine(filterContext.HttpContext.Request.Url.ToString());
-
-            stream.WriteLine("Exception: " + filterContext.Exception.Message);
-
-            stream.WriteLine("Inner Exception: " + filterContext.Exception.InnerException);
-
-            stream.WriteLine();
-            stream.WriteLine();
+            message.AppendLine("User-Agent: " + filterContext.HttpContext.Request.UserAgent);
+            message.Append(filterContext.HttpContext.Request.UserHostAddress);
+            message.Append(" ");
+            message.Append(filterContext.HttpContext.Request.HttpMethod.ToString());
+            message.Append(" ");
+            message.AppendLine(filterContext.HttpContext.Request.Url.ToString());
+            message.AppendLine("Exception: " + filterContext.Exception.Message);
+            message.AppendLine("Inner Exception: " + filterContext.Exception.InnerException);
 
 
-            stream.Dispose();
+            log.Error(message.ToString());
         }
     }
 }

--- a/Phoenix/Filters/ExceptionLogAttribute.cs
+++ b/Phoenix/Filters/ExceptionLogAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Phoenix.Filters
+{
+    public class ExceptionLogAttribute
+    {
+    }
+}

--- a/Phoenix/Filters/ExceptionLogAttribute.cs
+++ b/Phoenix/Filters/ExceptionLogAttribute.cs
@@ -1,11 +1,50 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
+using System.IO;
+using System.Web.Hosting;
+using System.Web.Mvc;
 
 namespace Phoenix.Filters
 {
-    public class ExceptionLogAttribute
+    public class ExceptionLogAttribute : FilterAttribute, IExceptionFilter
     {
+        public void OnException(ExceptionContext filterContext)
+        {
+            string today = DateTime.Today.ToShortDateString().Replace("/", "_");
+
+            // Msdn doesn't have enough documentation on DateTime, so I used:
+            // http://www.c-sharpcorner.com/uploadfile/mahesh/working-with-datetime-using-C-Sharp/
+            // to figure out the type of timestamp format I wanted
+            string timestamp = DateTime.Today.ToString("G");
+
+            string folderPath = "\\Logs\\";
+            Directory.CreateDirectory(HostingEnvironment.MapPath(folderPath));
+
+            var stream = File.AppendText(HostingEnvironment.MapPath(folderPath + today + ".log"));
+
+            stream.Write(timestamp);
+            stream.Write(" --- ");
+            stream.Write("[ERROR]");
+            stream.Write(" ");
+            // Unsolicited information: The user agent string is a mess.
+            // Here is an article to get you up to date:
+            // http://webaim.org/blog/user-agent-string-history/
+            // FUN
+            stream.WriteLine(filterContext.HttpContext.Request.UserAgent);
+            stream.Write(filterContext.HttpContext.Request.UserHostAddress);
+            stream.Write(" ");
+            stream.Write(filterContext.HttpContext.Request.HttpMethod.ToString());
+            stream.Write(" ");
+            stream.WriteLine(filterContext.HttpContext.Request.Url.ToString());
+
+            stream.WriteLine("Exception: " + filterContext.Exception.Message);
+
+            stream.WriteLine("Inner Exception: " + filterContext.Exception.InnerException);
+
+            stream.WriteLine();
+            stream.WriteLine();
+
+
+            stream.Dispose();
+        }
     }
 }

--- a/Phoenix/Global.asax.cs
+++ b/Phoenix/Global.asax.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
+﻿using Phoenix.Filters;
 using System.Web.Mvc;
 using System.Web.Optimization;
 using System.Web.Routing;
@@ -12,6 +9,9 @@ namespace Phoenix
     {
         protected void Application_Start()
         {
+            // Register global filters
+            GlobalFilters.Filters.Add(new ExceptionLogAttribute());
+
             AreaRegistration.RegisterAllAreas();
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);

--- a/Phoenix/Phoenix.csproj
+++ b/Phoenix/Phoenix.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Controllers\RciInputController.cs" />
     <Compile Include="Filters\CustomAuthenticationAttribute.cs" />
     <Compile Include="Filters\AdminAttribute.cs" />
+    <Compile Include="Filters\ExceptionLogAttribute.cs" />
     <Compile Include="Filters\RDAttribute.cs" />
     <Compile Include="Filters\ResLifeStaffAttribute.cs" />
     <Compile Include="Global.asax.cs">

--- a/Phoenix/Phoenix.csproj
+++ b/Phoenix/Phoenix.csproj
@@ -202,6 +202,7 @@
     </Compile>
     <Compile Include="Services\AdminDashboardService.cs" />
     <Compile Include="Services\DashboardService.cs" />
+    <Compile Include="Services\LoggerService.cs" />
     <Compile Include="Services\LoginService.cs" />
     <Compile Include="Services\RciComponentReassignService.cs" />
     <Compile Include="Services\RciInputService.cs" />

--- a/Phoenix/Services/LoggerService.cs
+++ b/Phoenix/Services/LoggerService.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.IO;
+using System.Web.Hosting;
+
+namespace Phoenix.Services
+{
+
+    /// <summary>
+    /// Simple logging class to log information to external sources e.g. files, maybe a table later on?
+    /// If you want to log to the console use the builtin Debug.WriteLine().
+    /// 
+    /// Later on, we can use this class to modify how things are logged at different levels, without changing code elsewhere.
+    /// </summary>
+    public class LoggerService
+    {
+        /// <summary>
+        /// Log information.
+        /// </summary>
+        /// <param name="message">Message to log</param>
+        public void Info(string message)
+        {
+            Log("INFO", message);
+        }
+
+        /// <summary>
+        /// Log Errors. Provide as much context information as possible.
+        /// </summary>
+        /// <param name="message">Message to log</param>
+        public void Error(string message)
+        {
+            Log("ERROR", message);
+        }
+
+        private void Log(string level, string message)
+        {
+            string today = DateTime.Today.ToShortDateString().Replace("/", "_");
+
+            // Msdn doesn't have enough documentation on DateTime, so I used:
+            // http://www.c-sharpcorner.com/uploadfile/mahesh/working-with-datetime-using-C-Sharp/
+            // to figure out the type of timestamp format I wanted
+            string timestamp = DateTime.Today.ToString("G");
+
+            string folderPath = "\\Logs\\";
+            Directory.CreateDirectory(HostingEnvironment.MapPath(folderPath));
+
+            var stream = File.AppendText(HostingEnvironment.MapPath(folderPath + today + ".log"));
+
+            stream.WriteLine(timestamp + " --- " + "[" + level + "]");
+            stream.Write(message);
+            stream.WriteLine();
+            stream.Dispose();
+
+        }
+    }
+}


### PR DESCRIPTION
🌮 **Exception logging for debugging.** 🌮 

#157 

The logs are written to "Logs\\_date_.log" at the root of the project application folder in the following format
```
7/30/2017 12:00:00 AM --- [ERROR] 
User-Agent: Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36
::1 GET https://localhost:44300/Dashboard
Exception: Hello there
Inner Exception: [INNER EXCEPTION GOES HERE IF ANY]
```

The `::1` will be the IP address. It is being displayed that way because the client was localhost.  
In case you are wondering why the User agent string lists a lot of browsers, read [this](http://webaim.org/blog/user-agent-string-history/).  