### PR TITLE
Fix spelling of drew building code.

### DIFF
--- a/Phoenix/App_Data/RoomComponents.xml
+++ b/Phoenix/App_Data/RoomComponents.xml
@@ -338,7 +338,7 @@
       </component>
     </components>
   </rci>
-  <rci roomType="individual" buildingCode="DRE">
+  <rci roomType="individual" buildingCode="DRW">
     <components>
       <component name="Bed Frame" description="Main Room">
         <cost name="Fixing Cost" approxCost="50" />


### PR DESCRIPTION
In Building Assign, the building code for drew was DRE instead of DRW.

I have corrected it in the table. 

This pull request corrects the spelling in the listing of room components.

