### PR TITLE
Generate the common area rci when ACs log in.

### DIFF
--- a/Phoenix.Tests/Pages/DashboardPage.cs
+++ b/Phoenix.Tests/Pages/DashboardPage.cs
@@ -319,7 +319,9 @@ namespace Phoenix.Tests.Pages
         {
             string roomID = apartmentNumber.Trim().ToLower();
 
-            var rciList = webDriver.FindElements(rciCards).Where(m => m.FindElement(rciCardBuildingAndRoom).Text.ToLower().Equals(roomID));
+            var rciList = webDriver.FindElements(rciCards).Where(m => 
+            m.FindElement(rciCardBuildingAndRoom).Text.ToLower().Equals(roomID)
+            && m.FindElement(rciCardStudentName).Text.ToLower().Equals("common area rci"));
 
             // There should be only one entry
             if (rciList.Count() > 1)

--- a/Phoenix/Controllers/DashboardController.cs
+++ b/Phoenix/Controllers/DashboardController.cs
@@ -92,8 +92,14 @@ namespace Phoenix.Controllers
             }
 
             var temp = (JArray)TempData["kingdom"];
+            var currentBuilding = (string)TempData["currentBuilding"];
+            var currentRoom = (string)TempData["currentRoom"];
             List<string> kingdom = temp.ToObject<List<string>>();
+            // Create missing individual rcis for the kindgom
             dashboardService.SyncRoomRcisFor(kingdom);
+            // Create a common area rci if missing
+            dashboardService.SyncCommonAreaRcisFor(currentBuilding, currentRoom);
+
             var buildingRCIs = dashboardService.GetRcisForBuilding(kingdom);
 
             return View(buildingRCIs);


### PR DESCRIPTION
When an AC/RA logs in, only individual RCIs were being created.

For an AC this meant that they couldn't start working on their common area RCI until one of their room mates arrived.

Some ACs might not have room mates. I'm specifically thinking of Ferrin Apartments. I don't know if that's the case right now. 

**If that is the case, I'll merge this.**

**If not, there is no need for this.**