### PR TITLE
Add stack trace

### DIFF
--- a/Phoenix/Filters/ExceptionLogAttribute.cs
+++ b/Phoenix/Filters/ExceptionLogAttribute.cs
@@ -29,6 +29,7 @@ namespace Phoenix.Filters
             message.AppendLine(filterContext.HttpContext.Request.Url.ToString());
             message.AppendLine("Exception: " + filterContext.Exception.Message);
             message.AppendLine("Inner Exception: " + filterContext.Exception.InnerException);
+            message.AppendLine("Stack Trace: " + filterContext.Exception.StackTrace);
 
 
             log.Error(message.ToString());


### PR DESCRIPTION
Current logs are not useful enough. It's hard to know what the real problem is when all the log shows is a null argument exception.

To improve it, I added a printing of the stack trace at the moment of the exception 🏟 

