### PR TITLE
Remove html validation for submitting passwords

### DIFF
--- a/Phoenix/Controllers/LoginController.cs
+++ b/Phoenix/Controllers/LoginController.cs
@@ -33,7 +33,9 @@ namespace Phoenix.Controllers
         }
 
         // POST: Login
-        [HttpPost]
+        // ValidateInput(false) is set so that all characters will be allowed for passwords
+        // Without it, a password with "<" or ">" for exmple will cause an exception to be thrown due to HTML content validation.
+        [HttpPost, ValidateInput(false)]
         public ActionResult Authenticate(LoginViewModel loginViewModel)
         {
 

--- a/Phoenix/Controllers/LoginController.cs
+++ b/Phoenix/Controllers/LoginController.cs
@@ -33,9 +33,7 @@ namespace Phoenix.Controllers
         }
 
         // POST: Login
-        // ValidateInput(false) is set so that all characters will be allowed for passwords
-        // Without it, a password with "<" or ">" for exmple will cause an exception to be thrown due to HTML content validation.
-        [HttpPost, ValidateInput(false)]
+        [HttpPost]
         public ActionResult Authenticate(LoginViewModel loginViewModel)
         {
 

--- a/Phoenix/Models/ViewModels/LoginViewModel.cs
+++ b/Phoenix/Models/ViewModels/LoginViewModel.cs
@@ -1,8 +1,11 @@
-﻿namespace Phoenix.Models.ViewModels
+﻿using System.Web.Mvc;
+
+namespace Phoenix.Models.ViewModels
 {
     public class LoginViewModel
     {
         public string Username { get; set; }
+        [AllowHtml]
         public string Password { get; set; }
         public string ErrorMessage { get; set; }
     }


### PR DESCRIPTION
When a user's password has HTML-like characters in it, ASP.NET automatically does input validation and throws an exception. This default behavior helps prevent things like cross-site scripting attacks. However, there are always cases when you want to allow users to enter html characters. 

In our case, passwords are one of those cases. Gordon allows students to have such characters in their passwords, so we need to override the default behavior.

[This](https://www.codeproject.com/Articles/995931/Preventing-XSS-Attacks-in-ASP-NET-MVC-using-Valida) is the link that helped me figure out how to do it

