### PR TITLE
Changing LDAP authentication to use integrated windows logon

### DIFF
--- a/Phoenix/Controllers/LoginController.cs
+++ b/Phoenix/Controllers/LoginController.cs
@@ -100,7 +100,7 @@ namespace Phoenix.Controllers
                     // e.g. user is not in accounts table for some reason
                     _ADContext.Dispose();
 
-                    loginViewModel.ErrorMessage = "Ther username/password combination provided is not valid.";
+                    loginViewModel.ErrorMessage = "The username/password combination provided is not valid.";
 
                     logger.Error(e, $"Username={username} provided correct credientials but was not found in the Accounts table, so was denied login.");
 

--- a/Phoenix/Services/LoginService.cs
+++ b/Phoenix/Services/LoginService.cs
@@ -31,9 +31,7 @@ namespace Phoenix.Services
                 ContextType.Domain,
                 "elder.gordon.edu:636",
                 "DC=gordon,DC=edu",
-                ContextOptions.Negotiate | ContextOptions.ServerBind | ContextOptions.SecureSocketLayer,
-                "CS-LDAP-CCT",
-                "QUl59QpdpL**sTwZ");
+                ContextOptions.Negotiate | ContextOptions.ServerBind | ContextOptions.SecureSocketLayer);
             // This password should probs be stored elsewhere
 
             return ADContext;

--- a/Phoenix/Web.Base.config
+++ b/Phoenix/Web.Base.config
@@ -65,7 +65,7 @@
   </entityFramework>
   <connectionStrings>
     <add name="RCIDatabase" connectionString="ReplaceMe Using Web.Config Transforms" providerName="System.Data.SqlClient"/>
-    <add name="RCIContext" connectionString="data source=SQLPROD01;initial catalog=RCITrain;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
+    <add name="RCIContext" connectionString="data source=ADMINPRODSQL.GORDON.EDU;initial catalog=RCITrain;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <system.webServer>
     <rewrite>

--- a/Phoenix/Web.Debug.config
+++ b/Phoenix/Web.Debug.config
@@ -9,7 +9,7 @@
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
     <connectionStrings>
       <add name="RCIDatabase"
-        connectionString="data source=SQLPROD01;initial catalog=RCITrain;integrated security=True;MultipleActiveResultSets=True;"
+        connectionString="data source=ADMINPRODSQL.GORDON.EDU;initial catalog=RCITrain;integrated security=True;MultipleActiveResultSets=True;"
         xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
     </connectionStrings>
   <system.web>

--- a/Phoenix/Web.Release.config
+++ b/Phoenix/Web.Release.config
@@ -9,7 +9,7 @@
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
     <connectionStrings>
       <add name="RCIDatabase"
-        connectionString="data source=SQLPROD01;initial catalog=RCI;integrated security=True;MultipleActiveResultSets=True;"
+        connectionString="data source=ADMINPRODSQL.GORDON.EDU;initial catalog=RCI;integrated security=True;MultipleActiveResultSets=True;"
         xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
     </connectionStrings>
   <system.web>

--- a/Phoenix/Web.config
+++ b/Phoenix/Web.config
@@ -66,10 +66,10 @@
     </providers>
   </entityFramework>
   <connectionStrings>
-    <add name="RCIDatabase" connectionString="data source=SQLPROD01;initial catalog=RCITrain;integrated security=True;MultipleActiveResultSets=True;"
+    <add name="RCIDatabase" connectionString="data source=ADMINPRODSQL.GORDON.EDU;initial catalog=RCITrain;integrated security=True;MultipleActiveResultSets=True;"
       providerName="System.Data.SqlClient"/>
     <add name="RCIContext"
-      connectionString="data source=SQLPROD01;initial catalog=RCITrain;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework"
+      connectionString="data source=ADMINPRODSQL.GORDON.EDU;initial catalog=RCITrain;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework"
       providerName="System.Data.SqlClient"/>
   </connectionStrings>
   <system.webServer>

--- a/Phoenix/Web.config
+++ b/Phoenix/Web.config
@@ -6,17 +6,19 @@
 <!-- CHANGES MADE DIRECTLY TO THE web.config WILL BE OVERWRITTEN -->
 <configuration>
   <configSections>
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <section name="entityFramework"
+      type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+      requirePermission="false"/>
   </configSections>
   <appSettings>
-    <add key="webpages:Version" value="3.0.0.0" />
-    <add key="webpages:Enabled" value="false" />
-    <add key="ClientValidationEnabled" value="true" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    <add key="webpages:Version" value="3.0.0.0"/>
+    <add key="webpages:Enabled" value="false"/>
+    <add key="ClientValidationEnabled" value="true"/>
+    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
   </appSettings>
   <system.web>
-    <compilation debug="true" targetFramework="4.6.1" />
-    <httpRuntime targetFramework="4.6.1" maxRequestLength="10000" />
+    <compilation debug="true" targetFramework="4.6.1"/>
+    <httpRuntime targetFramework="4.6.1" maxRequestLength="10000"/>
     <!-- Max request size in KB = 10 MB-->
 
   </system.web>
@@ -24,64 +26,67 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>
-        <parameter value="mssqllocaldb" />
+        <parameter value="mssqllocaldb"/>
       </parameters>
     </defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
     </providers>
   </entityFramework>
   <connectionStrings>
-    <add name="RCIDatabase" connectionString="data source=SQLPROD01;initial catalog=RCITrain;integrated security=True;MultipleActiveResultSets=True;" providerName="System.Data.SqlClient"/>
-    <add name="RCIContext" connectionString="data source=SQLPROD01;initial catalog=RCITrain;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
+    <add name="RCIDatabase" connectionString="data source=SQLPROD01;initial catalog=RCITrain;integrated security=True;MultipleActiveResultSets=True;"
+      providerName="System.Data.SqlClient"/>
+    <add name="RCIContext"
+      connectionString="data source=SQLPROD01;initial catalog=RCITrain;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework"
+      providerName="System.Data.SqlClient"/>
   </connectionStrings>
   <system.webServer>
     <rewrite>
       <rules>
         <rule name="Redirect to HTTPS" stopProcessing="true">
-          <match url="(.*)" />
+          <match url="(.*)"/>
           <conditions>
-            <add input="{HTTPS}" pattern="^OFF$" />
+            <add input="{HTTPS}" pattern="^OFF$"/>
           </conditions>
-          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="SeeOther" />
+          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="SeeOther"/>
         </rule>
       </rules>
     </rewrite>
     <security>
       <requestFiltering>
-        <requestLimits maxAllowedContentLength="10000000" />
+        <requestLimits maxAllowedContentLength="10000000"/>
         <!-- Max request size in bytes = 10 MB-->
       </requestFiltering>
     </security>


### PR DESCRIPTION
This PR removes the plaintext password from the LDAP connection therefore setting it to use windows integrated security. Since it runs on the server as an account with access and all Gordon accounts have access to LDAP, that should be a fine change to make.

If former student developers need to access the system to make changes, they may have to modify & bypass the authentication.

This PR also changes the DB connection strings to use adminprodsql, the load-balanced DNS name, rather than sqlprod01, a specific server. This is especially necessary as we are building new SQL Servers.